### PR TITLE
axosyslog: add scl.conf to scl package

### DIFF
--- a/syslog-ng/apkbuild/axoflow/syslog-ng/APKBUILD
+++ b/syslog-ng/apkbuild/axoflow/syslog-ng/APKBUILD
@@ -126,6 +126,7 @@ scl() {
 	depends="$pkgname=$pkgver-r$pkgrel"
 
 	_submv usr/share/syslog-ng/include/scl
+	_submv usr/share/syslog-ng/include/scl.conf
 }
 
 dev() {


### PR DESCRIPTION
Followup for https://github.com/syslog-ng/syslog-ng/pull/4534.

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>
