### PR TITLE
Multi arch OCI description fix

### DIFF
--- a/.github/workflows/ssc-stable.yml
+++ b/.github/workflows/ssc-stable.yml
@@ -77,6 +77,16 @@ jobs:
           images: ${{ env.DOCKER_IMAGE_NAME }}
           tags: type=match,pattern=ssc-(.*),group=1
           sep-tags: ','
+          labels: | # https://github.com/opencontainers/image-spec/blob/main/annotations.md
+            maintainer="axoflow.io"
+            org.opencontainers.image.title="AxoSyslog Splunk Connector"
+            org.opencontainers.image.description="A cloud-native distribution of syslog-ng by Axoflow"
+            org.opencontainers.image.authors="Axoflow"
+            org.opencontainers.image.vendor="Axoflow"
+            org.opencontainers.image.licenses="GPL-3.0-only"
+            org.opencontainers.image.source="https://github.com/axoflow/axosyslog-docker"
+            org.opencontainers.image.documentation="https://axoflow.com/docs/axosyslog/docs/"
+            org.opencontainers.image.url="https://axoflow.io/"
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v3
@@ -89,13 +99,6 @@ jobs:
           build-args: |
             SYSLOGNG_VERSION=${{ env.SYSLOG_NG_IMG_VERSION }}
             VERSION=${{ needs.version.outputs.version }}
-          labels: | # https://github.com/opencontainers/image-spec/blob/main/annotations.md
-            maintainer="axoflow.io"
-            org.opencontainers.image.title="AxoSyslog Splunk Connector"
-            org.opencontainers.image.description="A cloud-native distribution of syslog-ng by Axoflow"
-            org.opencontainers.image.authors="Axoflow"
-            org.opencontainers.image.vendor="Axoflow"
-            org.opencontainers.image.licenses="GPL-3.0-only"
-            org.opencontainers.image.source="https://github.com/axoflow/axosyslog-docker"
-            org.opencontainers.image.documentation="https://axoflow.com/docs/axosyslog/docs/"
-            org.opencontainers.image.url="https://axoflow.io/"
+          # description should be here because it is a multi-arch image
+          # see docs: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#adding-a-description-to-multi-arch-images
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=${{ fromJSON(steps.tags.outputs.json).labels['org.opencontainers.image.description'] }}

--- a/.github/workflows/syslog-ng-docker.yml
+++ b/.github/workflows/syslog-ng-docker.yml
@@ -75,6 +75,9 @@ jobs:
           platforms: ${{ env.PLATFORMS }}
           push: true
           tags: ${{ steps.tags.outputs.TAGS }}
+          # description should be here because it is a multi-arch image
+          # see docs: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#adding-a-description-to-multi-arch-images
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=${{ fromJSON(steps.stable-tags.outputs.json).labels['org.opencontainers.image.description'] }}
           build-args: |
             PKG_TYPE=${{ inputs.pkg-type }}
             SNAPSHOT_VERSION=${{ inputs.snapshot-version }}

--- a/syslog-ng/alpine.dockerfile
+++ b/syslog-ng/alpine.dockerfile
@@ -3,17 +3,6 @@ FROM alpine:3.18 as apkbuilder
 ARG PKG_TYPE=stable
 ARG SNAPSHOT_VERSION
 
-# https://github.com/opencontainers/image-spec/blob/main/annotations.md
-LABEL maintainer="axoflow.io"
-LABEL org.opencontainers.image.title="AxoSyslog"
-LABEL org.opencontainers.image.description="A cloud-native distribution of syslog-ng by Axoflow"
-LABEL org.opencontainers.image.authors="Axoflow"
-LABEL org.opencontainers.image.vendor="Axoflow"
-LABEL org.opencontainers.image.licenses="GPL-3.0-only"
-LABEL org.opencontainers.image.source="https://github.com/axoflow/axosyslog-docker"
-LABEL org.opencontainers.image.documentation="https://axoflow.com/docs/axosyslog/docs/"
-LABEL org.opencontainers.image.url="https://axoflow.io/"
-
 RUN apk add --update-cache \
       alpine-conf \
       alpine-sdk \
@@ -41,7 +30,18 @@ RUN mkdir packages \
 
 
 FROM alpine:3.18
-LABEL maintainer="László Várady <laszlo.varady@axoflow.com>"
+
+# https://github.com/opencontainers/image-spec/blob/main/annotations.md
+LABEL maintainer="axoflow.io"
+LABEL org.opencontainers.image.title="AxoSyslog"
+LABEL org.opencontainers.image.description="A cloud-native distribution of syslog-ng by Axoflow"
+LABEL org.opencontainers.image.authors="Axoflow"
+LABEL org.opencontainers.image.vendor="Axoflow"
+LABEL org.opencontainers.image.licenses="GPL-3.0-only"
+LABEL org.opencontainers.image.source="https://github.com/axoflow/axosyslog-docker"
+LABEL org.opencontainers.image.documentation="https://axoflow.com/docs/axosyslog/docs/"
+LABEL org.opencontainers.image.url="https://axoflow.io/"
+
 COPY --from=apkbuilder /home/builder/packages/ /
 COPY --from=apkbuilder /home/builder/.abuild/*.pub /etc/apk/keys/
 


### PR DESCRIPTION
The labels introduced in #45 are [not shown on ghcr.io](https://github.com/axoflow/axosyslog-docker/pkgs/container/axosyslog/131605762?tag=4.4.0) because for mult-arch images the `description` field should be filled [differently](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#adding-a-description-to-multi-arch-images).

Once the release job in my fork has finished running I'll link it to help with the review.
EDIT: forked release: https://github.com/overorion/axosyslog-docker/pkgs/container/axosyslog/135500889?tag=4.4.0-oci4
