### PR TITLE
gha: add metadata extraction step during nightly release as well

### DIFF
--- a/.github/workflows/syslog-ng-docker.yml
+++ b/.github/workflows/syslog-ng-docker.yml
@@ -46,8 +46,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (syslog-ng version) for Docker
-        if: inputs.pkg-type == 'stable'
-        id: stable-tags
+        id: docker-metadata-tags
         uses: docker/metadata-action@v3
         with:
           images: ${{ env.DOCKER_IMAGE_NAME }}
@@ -58,7 +57,7 @@ jobs:
         id: tags
         run: |
           if [[ '${{ inputs.pkg-type }}' = 'stable' ]]; then
-            TAGS='${{ steps.stable-tags.outputs.tags }}'
+            TAGS='${{ steps.docker-metadata-tags.outputs.tags }}'
           elif [[ '${{ inputs.pkg-type }}' = 'nightly' ]]; then
             TAGS="${DOCKER_IMAGE_NAME}:nightly,${DOCKER_IMAGE_NAME}:${{ inputs.snapshot-version }}"
           else
@@ -77,7 +76,7 @@ jobs:
           tags: ${{ steps.tags.outputs.TAGS }}
           # description should be here because it is a multi-arch image
           # see docs: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#adding-a-description-to-multi-arch-images
-          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=${{ fromJSON(steps.stable-tags.outputs.json).labels['org.opencontainers.image.description'] }}
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=${{ fromJSON(steps.docker-metadata-tags.outputs.json).labels['org.opencontainers.image.description'] }}
           build-args: |
             PKG_TYPE=${{ inputs.pkg-type }}
             SNAPSHOT_VERSION=${{ inputs.snapshot-version }}


### PR DESCRIPTION
In #49 the description was fixed for the stable release, however the metadata generation step is skipped during the nightly release, resulting in CI failure: https://github.com/axoflow/axosyslog-docker/actions/runs/6540259820

This PR enables that step regardless of the release type, so the required field will be filled.

See this workflow run: https://github.com/OverOrion/axosyslog-docker/actions/runs/6545245211