### PR TITLE
syslog-ng: add workaround for CVE-2023-43804

### DIFF
--- a/syslog-ng/alpine.dockerfile
+++ b/syslog-ng/alpine.dockerfile
@@ -73,6 +73,8 @@ RUN apk add --repository /axoflow -U --upgrade --no-cache \
     syslog-ng-tags-parser \
     syslog-ng-xml
 
+RUN /var/lib/syslog-ng-venv/bin/pip install -U urllib3==1.26.18
+
 EXPOSE 514/udp
 EXPOSE 601/tcp
 EXPOSE 6514/tcp


### PR DESCRIPTION
This is a workaround for CVE-2023-43804 by upgrading urllib3